### PR TITLE
Upgrade to python 3.10

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,21 +1,20 @@
 name: fcnd
 channels:
-    - conda-forge
+  - conda-forge
 dependencies:
-    - python==3.6.3
-    - matplotlib==2.1.1
-    - jupyter==1.0.0
-    - future==0.16.0
-    - lxml==4.1.1
-    - networkx==2.1
-    - scikit-image==0.13.1
-    - scipy==1.0.0
-    - shapely==1.6.4
-    - scikit-learn==0.19.1
-    - pip:
-        - git+https://github.com/udacity/udacidrone.git
-        - visdom==0.1.7
-        - bresenham==0.2
-        - msgpack==0.5.6
-        
-
+  - python=3.10.13
+  - matplotlib=3.6.2
+  - jupyter=1.0.0
+  - future=0.18.2
+  - lxml=4.9.2
+  - networkx=2.8.4
+  - scikit-image=0.20.0
+  - scipy=1.10.1
+  - shapely=2.0.1
+  - scikit-learn=1.2.2
+  - pip
+  - pip:
+      - git+https://github.com/udacity/udacidrone.git
+      - visdom==0.1.7
+      - bresenham==0.2
+      - msgpack==1.0.2


### PR DESCRIPTION
Issue:
https://knowledge.udacity.com/questions/1028179

Upgrade dependencies to work on Mac with M1 chip

Related issue:
https://knowledge.udacity.com/questions/1028179

WARNING!

Requires this pr to be approved as well:
https://github.com/udacity/udacidrone/pull/66